### PR TITLE
chore(__init__): add xform caster from string to integer

### DIFF
--- a/tap_appsflyer/__init__.py
+++ b/tap_appsflyer/__init__.py
@@ -83,13 +83,19 @@ def xform_empty_strings_to_none(record):
         if value == "":
             record[key] = None
 
+def xform_string_to_integer(record, field_name):
+	try:
+		record[field_name] = int(record[field_name])
+	except:
+	    raise ValueError("Cannot cast to int")
 
 def xform(record, schema):
     xform_empty_strings_to_none(record)
     xform_boolean_field(record, "wifi")
     xform_boolean_field(record, "is_retargeting")
+    xform_string_to_integer(record, "customer_user_id")
     return transform.transform(record, schema)
-
+	
 
 @attr.s
 class Stream(object):


### PR DESCRIPTION
First I was thinking about edit raw_datas schemas, but maybe with this workaround, it will be more flexible to avoid violation schema errors. I have no test environments through Singer, so I hadn't got any chances to test my code before create this pull request.
Thanks ;)

Gautier