### PR TITLE
chore(installations.json): add customer_user_id string type in schema

### DIFF
--- a/tap_appsflyer/schemas/raw_data/installations.json
+++ b/tap_appsflyer/schemas/raw_data/installations.json
@@ -344,7 +344,8 @@
     "customer_user_id": {
       "type": [
         "null",
-        "integer"
+        "integer",
+        "string"
       ]
     },
     "imei": {


### PR DESCRIPTION
Hello,

We now have the same issue for `installs` table for this tap.
I added string type to `customer_user_id` like I did in than my previous PR for in_app_events table.
Thanks,
