### PR TITLE
Skip transformation if boolean field is null

### DIFF
--- a/tap_appsflyer/__init__.py
+++ b/tap_appsflyer/__init__.py
@@ -72,7 +72,11 @@ def xform_datetime_field(record, field_name):
 
 
 def xform_boolean_field(record, field_name):
-    if record[field_name].lower() == "TRUE".lower():
+    value = record[field_name]
+    if value is None:
+        return
+
+    if value.lower() == "TRUE".lower():
         record[field_name] = True
     else:
         record[field_name] = False


### PR DESCRIPTION
Fixes #8.

Since all of the boolean fields in the schemas are nullable, this will just pass through if `None` comes through as a value for a boolean field.