### PR TITLE
change while loop conditions to fix infinite loop

### DIFF
--- a/tap_appsflyer/__init__.py
+++ b/tap_appsflyer/__init__.py
@@ -386,7 +386,7 @@ def sync_in_app_events():
     from_datetime = get_start("in_app_events")
     to_datetime = get_stop(from_datetime, stop_time, 10)
 
-    while to_datetime <= stop_time:
+    while from_datetime < stop_time:
         LOGGER.info("Syncing data from %s to %s", from_datetime, to_datetime)
         params = dict()
         params["from"] = from_datetime.strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
The while loop for `in_app_events` had:
```
while to_datetime <= stop_datetime
```
which caused an infinite loop since, once the stream caught up, `to_datetime` was equal to `stop_datetime`.  Since there is a limit on the requested reports, once the tap would loop until it hit that limit and then receive a 400 and error out.

This changes the loop to 
```
while from_datetime < to_datetime
```
