### PR TITLE
updated version of requests library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'attrs==16.3.0',
         'singer-python==1.6.0a2',
-        'requests==2.12.4',
+        'requests==2.20.0',
         'backoff==1.3.2',
     ],
     extras_require={


### PR DESCRIPTION
Our security team got an alert about a cve in https://github.com/singer-io/tap-appsflyer/blob/master/setup.py. specifically that  'requests==2.12.4', should be updated to 2.20.0 or newer.