### PR TITLE
Change event revenue attributes to type: numeric

### DIFF
--- a/tap_appsflyer/schemas/raw_data/in_app_events.json
+++ b/tap_appsflyer/schemas/raw_data/in_app_events.json
@@ -434,13 +434,13 @@
     "event_revenue": {
       "type": [
         "null",
-        "string"
+        "numeric"
       ]
     },
     "event_revenue_usd": {
       "type": [
         "null",
-        "string"
+        "numeric"
       ]
     },
     "event_revenue_currency": {


### PR DESCRIPTION
event_revenue and event_revenue_usd are of type string. This causes issues in BigQuery when doing sums. Changed to numeric

# Description of change
event_revenue and event_revenue_usd are of type string. This causes issues in BigQuery when doing sums. Changed to numeric

# Manual QA steps
 - 
 
# Risks
 - Unsure whether this would break non BigQuery integrations?
 
# Rollback steps
 - revert this branch
