### PR TITLE
Add SKAN Aggregated Performance API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ env.sh
 config.json
 .autoenv.zsh
 *~
+.idea
 
 *config.json
 *catalog.json

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ data following the [Singer spec](https://github.com/singer-io/getting-started/bl
 
 This tap:
 - Pulls raw data from AppFlyer's [Raw Data Reports V5 API](https://support.appsflyer.com/hc/en-us/articles/208387843-Raw-Data-Reports-V5-)
+- Pulls aggregate data from AppFlyer's [SKAN Aggregated Report API](https://support.appsflyer.com/hc/en-us/articles/360014104157)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 

--- a/tap_appsflyer/schemas/raw_data/skan_aggregated_perf.json
+++ b/tap_appsflyer/schemas/raw_data/skan_aggregated_perf.json
@@ -1,0 +1,234 @@
+{
+  "type": "object",
+  "properties": {
+    "date": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "media_source": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "site_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "country": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "af_attribution_flag": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "installs": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "click_through_installs": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "view_through_installs": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "null_conversion_value_rate": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_rate": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "converted_users": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "converted_users_installs": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "total_revenue": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "total_cost": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "roi": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "arpu": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "average_ecpi": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "initial_loading_unique_users": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "initial_loading_event_counter": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_attempt_unique_users": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_attempt_event_counter": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_getting_started_unique_users": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_getting_started_event_counter": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_mobile_number_unique_users": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_mobile_number_event_counter": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_success_unique_users": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_success_event_counter": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_verification_code_unique_users": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "register_step_verification_code_event_counter": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Description of change
Add new stream option - the SKAN aggregated performance API.

Upgraded the existing streams to use the v2 interfaces which use an authorization header instead of request parameter to send the api-token.

# Manual QA steps
Ran the full set of reports against my own appsflyer account
 
# Risks
Users will need to exchange their v1 token for the v2 token.
 
# Rollback steps
 - revert this branch
