### PR TITLE
fix: timezone aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,45 @@ This tap:
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 
+## Configuration
+
+### Required Parameters
+
+- `app_id` - Your AppsFlyer application ID
+- `api_token` - Your AppsFlyer API token
+
+### Optional Parameters
+
+- `start_date` - The date to begin syncing data from (format: `YYYY-MM-DD`)
+- `base_url` - Custom base URL for the AppsFlyer API (defaults to `https://hq1.appsflyer.com`)
+- `user_agent` - Custom user agent string for API requests
+- `organic_installs` - Boolean flag to sync organic installs (defaults to `false`)
+- `event_name` - Filter in-app events by specific event names. Can be provided as:
+  - A comma-separated string: `"af_purchase,ftd"`
+  - An array of strings: `["af_purchase", "ftd"]`
+
+### Example Configuration
+
+```json
+{
+  "app_id": "com.example.app",
+  "api_token": "your-api-token-here",
+  "start_date": "2025-01-01",
+  "event_name": "af_purchase,ftd"
+}
+```
+
+Or with event_name as an array:
+
+```json
+{
+  "app_id": "com.example.app",
+  "api_token": "your-api-token-here",
+  "start_date": "2025-01-01",
+  "event_name": ["af_purchase", "ftd"]
+}
+```
+
 ---
 
 Copyright &copy; 2017 Stitch, Inc.

--- a/tap_appsflyer/__init__.py
+++ b/tap_appsflyer/__init__.py
@@ -570,6 +570,17 @@ def sync_in_app_events():
         params = dict()
         params["from"] = from_datetime.strftime("%Y-%m-%d %H:%M")
         params["to"] = to_datetime.strftime("%Y-%m-%d %H:%M")
+        
+        # Add optional event_name filter if provided in config
+        if "event_name" in CONFIG and CONFIG["event_name"]:
+            event_name_value = CONFIG["event_name"]
+            # Support both list and string formats
+            if isinstance(event_name_value, list):
+                params["event_name"] = ",".join(event_name_value)
+            else:
+                params["event_name"] = event_name_value
+            LOGGER.info("Filtering by event_name: %s", params["event_name"])
+        
         api_token = CONFIG["api_token"]
 
         url = get_url("in_app_events", app_id=CONFIG["app_id"])


### PR DESCRIPTION
# Description of change
This pull request improves the handling of datetime objects in `tap_appsflyer/__init__.py` to ensure all datetime values are timezone-aware (specifically in UTC). This helps prevent subtle bugs when comparing or manipulating datetimes, especially when mixing naive and timezone-aware objects.

`TypeError: can't compare offset-naive and offset-aware datetimes`

**Timezone handling improvements:**

* Added a new `ensure_timezone_aware(dt)` helper function that ensures any datetime object is timezone-aware in UTC, assuming naive objects are in UTC and leaving aware objects unchanged.
* Updated the `get_stop` function to use `ensure_timezone_aware` for both `start_datetime` and `stop_time`, ensuring safe and consistent datetime comparisons.
* Modified the call to `datetime.datetime.now()` in `sync_organic_installs` to explicitly use UTC (`datetime.datetime.now(pytz.utc)`), aligning with the new timezone-aware handling.
 
# Risks
 - None
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
